### PR TITLE
Add AUTHORIZATION header support in AuthController

### DIFF
--- a/backend/LegacyLoomApplication/RequestFeatureShared/Constants/HeaderKey.cs
+++ b/backend/LegacyLoomApplication/RequestFeatureShared/Constants/HeaderKey.cs
@@ -9,5 +9,6 @@ namespace RequestFeatureShared.Constants
     public class HeaderKey
     {
         public static string PAGINATION { get; } = "X-Pagination";
+        public static string AUTHORIZATION { get; } = "Authorization";
     }
 }

--- a/backend/LegacyLoomApplication/UserAuthenticationService/Controllers/AuthController.cs
+++ b/backend/LegacyLoomApplication/UserAuthenticationService/Controllers/AuthController.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using System.Threading.Tasks;
 using UserAuthenticationService.DTOs.UserAuthenticationDTOs;
 using UserAuthenticationService.Services;
 using ServiceResponseShared;
 using System.Net;
+using RequestFeatureShared.Constants;
 
 namespace UserAuthenticationService.Controllers
 {
@@ -33,6 +33,7 @@ namespace UserAuthenticationService.Controllers
                 return Unauthorized(ServiceResponse<UserLoginResponse>.Failure(response.ErrorMessage ?? "Invalid credentials", response.Errors, (int)HttpStatusCode.Unauthorized));
             }
 
+            Response.Headers.Append(HeaderKey.AUTHORIZATION, $"Bearer {response.Data?.Token}");
             return StatusCode(response.StatusCode, response);
         }
         
@@ -51,6 +52,7 @@ namespace UserAuthenticationService.Controllers
                 return Unauthorized(ServiceResponse<UserLoginResponse>.Failure(response.ErrorMessage ?? "Invalid credentials", response.Errors, (int)HttpStatusCode.Unauthorized));
             }
 
+            Response.Headers.Append(HeaderKey.AUTHORIZATION, $"Bearer {response.Data?.Token}");
             return StatusCode(response.StatusCode, response);
         }
 
@@ -58,6 +60,7 @@ namespace UserAuthenticationService.Controllers
         public ActionResult<ServiceResponse<UserLoginResponse>> Logout()
         {
             var response = _authService.GenerateTokenForLogout();
+            Response.Headers.Append(HeaderKey.AUTHORIZATION, $"Bearer {response.Data?.Token}");
             return StatusCode(response.StatusCode, response);
         }
     }


### PR DESCRIPTION
- Introduced a new static string property `AUTHORIZATION` in the `HeaderKey` class.
- Removed unused `using System.Threading.Tasks;` directive in `AuthController.cs`.
- Added `using RequestFeatureShared.Constants;` to access `HeaderKey`.
- Appended the authorization token to response headers in both `LoginUsingEmail` and `Logout` methods.