### PR TITLE
Update rate limits, pagination, and security features

### DIFF
--- a/LegacyLoomApplication/LegacyLoomApplicationGateway/Configurations/globalConfig.json
+++ b/LegacyLoomApplication/LegacyLoomApplicationGateway/Configurations/globalConfig.json
@@ -116,7 +116,7 @@
       "RateLimitOptions": {
         "EnableRateLimiting": true,
         "Period": "20s",
-        "Limit": 5,
+        "Limit": 10,
         "PeriodTimespan": 10,
         "ClientIdHeader": "Authorization"
       },

--- a/LegacyLoomApplication/LegacyLoomApplicationGateway/Extensions/CorsConfigurationExtension.cs
+++ b/LegacyLoomApplication/LegacyLoomApplicationGateway/Extensions/CorsConfigurationExtension.cs
@@ -13,7 +13,8 @@
                                   {
                                       policy.WithOrigins(origins)
                                             .AllowAnyHeader()
-                                            .AllowAnyMethod();
+                                            .AllowAnyMethod()
+                                            .WithExposedHeaders("X-Pagination");
                                   });
             });
         }

--- a/LegacyLoomApplication/TimelineService/Services/TimelineService.cs
+++ b/LegacyLoomApplication/TimelineService/Services/TimelineService.cs
@@ -37,7 +37,7 @@ namespace TimelineService.Services
                 var orderedTimelines = _sortHelper.ApplySort(timelines.AsQueryable<Timeline>(), timelineRequestParameters.OrderBy);
 
                 var count = timelines.Count;
-                var result = orderedTimelines.Skip((timelineRequestParameters.PageNumber - 1 * timelineRequestParameters.PageSize)).ToList();
+                var result = orderedTimelines.Skip((timelineRequestParameters.PageNumber - 1 * timelineRequestParameters.PageSize)).Take(timelineRequestParameters.PageSize).ToList();
 
                 var pagedListTimelines = PagedList<Timeline>.ToPagedList(result, count, timelineRequestParameters.PageNumber, timelineRequestParameters.PageSize);
                 var listOfTimeline = _mapper.Map<IEnumerable<Timeline>>(pagedListTimelines);
@@ -74,15 +74,17 @@ namespace TimelineService.Services
                 var _timelineCollection = await _mongoRepository.GetTimelineCollectionContext();
                 var timelines = await _timelineCollection.Find(s => !s.IsDeleted && s.CreatedBy == userId).ToListAsync();
                 
-                foreach(var timeline in timelines)
-                {
-                    timeline.Story.Content = new String(timeline.Story.Content.Take(150).ToArray());
-                }
 
                 var orderedTimelines = _sortHelper.ApplySort(timelines.AsQueryable<Timeline>(), timelineRequestParameters.OrderBy);
 
                 var count = timelines.Count;
-                var result = orderedTimelines.Skip((timelineRequestParameters.PageNumber - 1 * timelineRequestParameters.PageSize)).ToList();
+                var n_result = orderedTimelines.Skip(((timelineRequestParameters.PageNumber - 1) * timelineRequestParameters.PageSize));
+                var result = n_result.Take(timelineRequestParameters.PageSize).ToList();
+
+                foreach(var timeline in result)
+                {
+                    timeline.Story.Content = new String(timeline.Story.Content.Take(150).ToArray());
+                }
 
                 var pagedListTimelines = PagedList<Timeline>.ToPagedList(result, count, timelineRequestParameters.PageNumber, timelineRequestParameters.PageSize);
                 var listOfTimeline = _mapper.Map<IEnumerable<Timeline>>(pagedListTimelines);
@@ -112,7 +114,7 @@ namespace TimelineService.Services
                 var orderedTimelines = _sortHelper.ApplySort(timelines.AsQueryable<Timeline>(), timelineRequestParameters.OrderBy);
 
                 var count = timelines.Count;
-                var result = orderedTimelines.Skip((timelineRequestParameters.PageNumber - 1 * timelineRequestParameters.PageSize)).ToList();
+                var result = orderedTimelines.Skip((timelineRequestParameters.PageNumber - 1 * timelineRequestParameters.PageSize)).Take(timelineRequestParameters.PageSize).ToList();
 
                 var pagedListTimelines = PagedList<Timeline>.ToPagedList(result, count, timelineRequestParameters.PageNumber, timelineRequestParameters.PageSize);
                 return
@@ -144,7 +146,7 @@ namespace TimelineService.Services
                 var orderedTimelines = _sortHelper.ApplySort(timelines.AsQueryable<Timeline>(), timelineRequestParameters.OrderBy);
 
                 var count = timelines.Count;
-                var result = orderedTimelines.Skip((timelineRequestParameters.PageNumber - 1 * timelineRequestParameters.PageSize)).ToList();
+                var result = orderedTimelines.Skip((timelineRequestParameters.PageNumber - 1 * timelineRequestParameters.PageSize)).Take(timelineRequestParameters.PageSize).ToList();
 
                 var pagedListTimelines = PagedList<Timeline>.ToPagedList(result, count, timelineRequestParameters.PageNumber, timelineRequestParameters.PageSize);
                 return
@@ -348,7 +350,7 @@ namespace TimelineService.Services
                     .Find(timeline => timeline.SharedWith != null && timeline.SharedWith.Contains(userId.ToString()) && timeline.Visibility == TimelineVisibility.PUBLIC && !timeline.IsDeleted).ToListAsync();
                 var orderedTimlinesByUserId = _sortHelper.ApplySort(timelinesByUser.AsQueryable(), timelineRequestParameters.OrderBy).ToList();
                 var count = timelinesByUser.Count;
-                var result = orderedTimlinesByUserId.Skip((timelineRequestParameters.PageNumber - 1) * timelineRequestParameters.PageSize).ToList();
+                var result = orderedTimlinesByUserId.Skip((timelineRequestParameters.PageNumber - 1) * timelineRequestParameters.PageSize).Take(timelineRequestParameters.PageSize).ToList();
                 var pagedList = PagedList<Timeline>.ToPagedList(result, count, timelineRequestParameters.PageNumber, timelineRequestParameters.PageSize);
                 return
                     (

--- a/LegacyLoomApplication/UserAuthenticationService/Controllers/AuthController.cs
+++ b/LegacyLoomApplication/UserAuthenticationService/Controllers/AuthController.cs
@@ -34,6 +34,14 @@ namespace UserAuthenticationService.Controllers
             }
 
             Response.Headers.Append(HeaderKey.AUTHORIZATION, $"Bearer {response.Data?.Token}");
+            Response.Cookies.Append(HeaderKey.AUTHORIZATION, value: response.Data?.Token, new CookieOptions()
+            {
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteMode.None,
+                Path = "/",
+                Expires = DateTimeOffset.UtcNow.AddMinutes(60)
+            });
             return StatusCode(response.StatusCode, response);
         }
         
@@ -53,6 +61,14 @@ namespace UserAuthenticationService.Controllers
             }
 
             Response.Headers.Append(HeaderKey.AUTHORIZATION, $"Bearer {response.Data?.Token}");
+            Response.Cookies.Append(HeaderKey.AUTHORIZATION, value: response.Data?.Token, new CookieOptions()
+            {
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteMode.None,
+                Path = "/",
+                Expires = DateTimeOffset.UtcNow.AddMinutes(60)
+            });
             return StatusCode(response.StatusCode, response);
         }
 
@@ -61,6 +77,14 @@ namespace UserAuthenticationService.Controllers
         {
             var response = _authService.GenerateTokenForLogout();
             Response.Headers.Append(HeaderKey.AUTHORIZATION, $"Bearer {response.Data?.Token}");
+            Response.Cookies.Append(HeaderKey.AUTHORIZATION, value: response.Data?.Token, new CookieOptions()
+            {
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteMode.None,
+                Path = "/",
+                Expires = DateTimeOffset.UtcNow.AddMinutes(60)
+            });
             return StatusCode(response.StatusCode, response);
         }
     }


### PR DESCRIPTION
- Increased rate limit in `globalConfig.json` from 5 to 10.
- Added "X-Pagination" header to CORS policy in `CorsConfigurationExtension.cs`.
- Improved pagination logic in `TimelineService.cs` to limit results by page size and truncate timeline story content to 150 characters.
- Enhanced security in `AuthController.cs` by setting the authorization token as a secure cookie with HttpOnly, Secure, and SameSite=None options.